### PR TITLE
Fix tool installation bug

### DIFF
--- a/src/microbots/tools/tool.py
+++ b/src/microbots/tools/tool.py
@@ -201,11 +201,11 @@ def install_tools(env: Environment, tools: List[Tool]):
         for tool in tools:
             _install_tool(env, tool)
 
-        for env_variable in tool.env_variables:
-            _copy_env_variable(env, env_variable)
+            for env_variable in tool.env_variables:
+                _copy_env_variable(env, env_variable)
 
-        for file_copy in tool.files_to_copy or []:
-            _copy_file(env, file_copy)
+            for file_copy in tool.files_to_copy or []:
+                _copy_file(env, file_copy)
 
         for tool in tools:
             _verify_tool_installation(env, tool)


### PR DESCRIPTION
Bug: When the code tries to process environment variables and file copies, it's only processing them for the last tool in the list, completely ignoring the environment variables and files for all other tools.