### PR TITLE
fix: accept LLM output when command key missing but task_done is True

### DIFF
--- a/src/microbots/MicroBot.py
+++ b/src/microbots/MicroBot.py
@@ -227,7 +227,17 @@ class MicroBot:
             error="Did not complete",
         )
         logger.info("%s TASK STARTED : %s...", LogLevelEmoji.INFO, task)
-
+        if llm_response.task_done is True:
+            if llm_response.thoughts:
+                logger.info(
+                    f" LLM final thoughts: {llm_response.thoughts}",
+                )
+            logger.info("TASK COMPLETED : %s...", task[0:15])
+            return BotRunResult(
+                status=True, 
+                result=llm_response.thoughts, 
+                error=None
+            )
         while llm_response.task_done is False:
             # increment iteration count
             self.iteration_count += 1


### PR DESCRIPTION
## Problem
When LLM sets task_done=True but does not include a command key,
the bot crashes while trying to process the missing command.

Fixes #78

## Fix
Added early return check — if task_done is True before the main
loop, bot returns successfully without processing command.

## Testing
Pass LLM response with task_done=True and no command key —
bot should return BotRunResult with status=True.