### PR TITLE
microbots python 3.13 installation issue fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,35 @@ on:
     # Allow manual triggering
 
 jobs:
+  install-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Install package and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Verify import
+        run: python -c "import microbots; print('microbots imported on Python', __import__('sys').version)"
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - name: Install package and dependencies
+      - name: Install package (dependency resolution via metadata)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-
+          python -m pip install .
       - name: Verify import
         run: python -c "import microbots; print('microbots imported on Python', __import__('sys').version)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.11"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.12.15
+aiohttp==3.14.1
 aiosignal==1.4.0
 annotated-types==0.7.0
 anthropic==0.75.0
@@ -26,12 +26,13 @@ httpx==0.28.1
 huggingface_hub==1.3.2
 idna==3.10
 iniconfig==2.1.0
-jiter==0.11.0
+jiter==0.15.0
 markdown-it-py==4.0.0
 mdurl==0.1.2
 multidict==6.6.4
 multiprocess==0.70.18
-numpy==1.26.4
+numpy==2.2.6; python_version < "3.14"
+numpy==2.5.0; python_version >= "3.14"
 openai==1.107.3
 packaging==25.0
 pandas==3.0.0
@@ -40,15 +41,15 @@ pluggy==1.6.0
 propcache==0.3.2
 ptyprocess==0.7.0
 pyarrow==23.0.0
-pydantic==2.11.9
-pydantic_core==2.33.2
+pydantic==2.12.4
+pydantic_core==2.41.5
 Pygments==2.19.2
 pytest==8.4.2
 pytest-cov==7.0.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-multipart==0.0.20
-PyYAML==6.0.2
+PyYAML==6.0.3
 requests==2.32.5
 rich==14.1.0
 shellingham==1.5.4
@@ -58,7 +59,7 @@ starlette==0.47.3
 swe-rex==1.4.0
 tqdm==4.67.1
 typer-slim==0.21.1
-typing-inspection==0.4.1
+typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.5.0
 uvicorn==0.35.0

--- a/src/microbots/extras/mount.py
+++ b/src/microbots/extras/mount.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 from enum import StrEnum
-from pathlib import Path
+from pathlib import PurePosixPath
 
 from microbots.constants import PermissionLabels, PermissionMapping
-from microbots.utils.path import PathInfo, get_path_info, ends_with_separator
+from microbots.utils.path import PathInfo, ends_with_separator, get_path_info
 
 
 class MountType(StrEnum):
@@ -57,7 +57,12 @@ class Mount:
         self.permission_key = PermissionMapping.MAPPING.get(self.permission)
         self.host_path_info = get_path_info(self.host_path)
 
-        sandbox_path = Path(self.sandbox_path)
+        # The sandbox is always a POSIX (Linux) container, so the sandbox
+        # path must be interpreted as a POSIX path regardless of the host OS.
+        # Using pathlib.Path here would resolve to WindowsPath on Windows,
+        # which incorrectly reports POSIX absolute paths like "/var/log" as
+        # relative (Windows requires a drive letter for an absolute path).
+        sandbox_path = PurePosixPath(self.sandbox_path)
 
         # Validate that sandbox_path is absolute
         if not sandbox_path.is_absolute():

--- a/src/microbots/extras/mount.py
+++ b/src/microbots/extras/mount.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 from enum import StrEnum
-from pathlib import PurePosixPath
+from pathlib import Path
 
 from microbots.constants import PermissionLabels, PermissionMapping
-from microbots.utils.path import PathInfo, ends_with_separator, get_path_info
+from microbots.utils.path import PathInfo, get_path_info, ends_with_separator
 
 
 class MountType(StrEnum):
@@ -57,12 +57,7 @@ class Mount:
         self.permission_key = PermissionMapping.MAPPING.get(self.permission)
         self.host_path_info = get_path_info(self.host_path)
 
-        # The sandbox is always a POSIX (Linux) container, so the sandbox
-        # path must be interpreted as a POSIX path regardless of the host OS.
-        # Using pathlib.Path here would resolve to WindowsPath on Windows,
-        # which incorrectly reports POSIX absolute paths like "/var/log" as
-        # relative (Windows requires a drive letter for an absolute path).
-        sandbox_path = PurePosixPath(self.sandbox_path)
+        sandbox_path = Path(self.sandbox_path)
 
         # Validate that sandbox_path is absolute
         if not sandbox_path.is_absolute():


### PR DESCRIPTION
Fixes : https://github.com/microsoft/microbots/issues/137

Python 3.13 — ✅ verified
In a fresh CPython 3.13.7 venv. It installed all dependencies (numpy 2.2.6 selected via marker) and import microbots succeeded. 

Python 3.14 — ✅ verified
Install: resolves cleanly (numpy 2.5.0 selected via marker) — verified on real 3.14.


Created Tests to verify microbots installation on `3.11, 3.12, 3.13, 3.14`
<img width="1613" height="320" alt="image" src="https://github.com/user-attachments/assets/4ef9b646-1649-4ef3-aca2-ea34a8ea955d" />
