### PR TITLE
Publish Log Analysis Bot Thought Process to optional file

### DIFF
--- a/azure-pipelines/MicrobotsLogAnalyzerTask/index.js
+++ b/azure-pipelines/MicrobotsLogAnalyzerTask/index.js
@@ -49,6 +49,7 @@ function getInputs() {
     codebasePath: tl.getPathInput("codebasePath", true, true),
     logFilePath: input("logFilePath", true),
     outputFilePath: input("outputFilePath", false),
+    debuggingLogFile: input("debuggingLogFile", false),
     additionalContext: input("additionalContext", false),
     timeoutSeconds: input("timeoutSeconds", false) || DEFAULT_TIMEOUT_SECONDS,
     maxIterations: input("maxIterations", false),
@@ -95,24 +96,34 @@ function validateInputs(inputs) {
   }
 
   if (inputs.outputFilePath) {
-    if (!path.isAbsolute(inputs.outputFilePath)) {
-      throw new Error(`outputFilePath must be an absolute path: ${inputs.outputFilePath}`);
-    }
+    inputs.outputFilePath = validateWritableFilePath(inputs.outputFilePath, "outputFilePath");
+  }
 
-    inputs.outputFilePath = path.resolve(inputs.outputFilePath);
-    const extension = path.extname(inputs.outputFilePath).toLowerCase();
-    if (extension !== ".txt" && extension !== ".md" && extension !== ".log") {
-      throw new Error(`outputFilePath must end with .txt, .md, or .log: ${inputs.outputFilePath}`);
-    }
-
-    if (fs.existsSync(inputs.outputFilePath) && fs.statSync(inputs.outputFilePath).isDirectory()) {
-      throw new Error(`outputFilePath must be a file path, not a directory: ${inputs.outputFilePath}`);
-    }
+  if (inputs.debuggingLogFile) {
+    inputs.debuggingLogFile = validateWritableFilePath(inputs.debuggingLogFile, "debuggingLogFile");
   }
 
   if (inputs.additionalContext && inputs.additionalContext.length > MAX_USER_PROMPT_LENGTH) {
     throw new Error(`additionalContext must be ${MAX_USER_PROMPT_LENGTH} characters or fewer`);
   }
+}
+
+function validateWritableFilePath(filePath, label) {
+  if (!path.isAbsolute(filePath)) {
+    throw new Error(`${label} must be an absolute path: ${filePath}`);
+  }
+
+  const resolved = path.resolve(filePath);
+  const extension = path.extname(resolved).toLowerCase();
+  if (extension !== ".txt" && extension !== ".md" && extension !== ".log") {
+    throw new Error(`${label} must end with .txt, .md, or .log: ${resolved}`);
+  }
+
+  if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+    throw new Error(`${label} must be a file path, not a directory: ${resolved}`);
+  }
+
+  return resolved;
 }
 
 async function loginWithServiceConnection(serviceConnection) {
@@ -179,16 +190,16 @@ function microbotsEnvironment(inputs) {
   });
 }
 
-function ensureOutputParentDirectory(outputFilePath) {
+function ensureOutputParentDirectory(outputFilePath, description) {
   if (!outputFilePath) return;
 
   const outputDirectory = path.dirname(outputFilePath);
   if (fs.existsSync(outputDirectory) && !fs.statSync(outputDirectory).isDirectory()) {
-    throw new Error(`outputFilePath parent must be a directory: ${outputDirectory}`);
+    throw new Error(`${description} parent must be a directory: ${outputDirectory}`);
   }
 
   fs.mkdirSync(outputDirectory, { recursive: true });
-  console.log(`##[section]MicrobotsLogAnalyzer: analysis output will overwrite ${outputFilePath}`);
+  console.log(`##[section]MicrobotsLogAnalyzer: ${description} will overwrite ${outputFilePath}`);
 }
 
 function runLogAnalyzer(python, inputs) {
@@ -201,10 +212,12 @@ function runLogAnalyzer(python, inputs) {
   ];
 
   if (inputs.outputFilePath) args.push("--output-file", inputs.outputFilePath);
+  if (inputs.debuggingLogFile) args.push("--debug-log-file", inputs.debuggingLogFile);
   if (inputs.additionalContext) args.push("--user-prompt", inputs.additionalContext);
   if (inputs.maxIterations) args.push("--max-iterations", inputs.maxIterations);
 
-  ensureOutputParentDirectory(inputs.outputFilePath);
+  ensureOutputParentDirectory(inputs.outputFilePath, "analysis output");
+  ensureOutputParentDirectory(inputs.debuggingLogFile, "debugging log");
   runCommand(python, args, microbotsEnvironment(inputs));
 }
 

--- a/azure-pipelines/MicrobotsLogAnalyzerTask/log_analyzer_runner.py
+++ b/azure-pipelines/MicrobotsLogAnalyzerTask/log_analyzer_runner.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 import textwrap
@@ -17,6 +18,7 @@ def parse_args():
     parser.add_argument("--log-file-path", required=True)
     parser.add_argument("--timeout-seconds", required=True, type=int)
     parser.add_argument("--output-file")
+    parser.add_argument("--debug-log-file")
     parser.add_argument("--user-prompt")
     parser.add_argument("--max-iterations", type=int)
     return parser.parse_args()
@@ -38,6 +40,20 @@ def write_text_file(file_path, content):
         output_file.write(content)
 
 
+def configure_debug_logging(debug_log_file):
+    """Capture Microbots runtime logs (thoughts, tool calls, command output) to a file."""
+    os.makedirs(os.path.dirname(debug_log_file), exist_ok=True)
+    file_handler = logging.FileHandler(debug_log_file, mode="w", encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(file_handler)
+
+
 def main():
     args = parse_args()
     codebase_path = os.path.abspath(args.codebase_path)
@@ -46,6 +62,8 @@ def main():
     max_iterations = args.max_iterations
 
     os.chdir(codebase_path)
+    if args.debug_log_file:
+        configure_debug_logging(args.debug_log_file)
     log(
         f"MicrobotsLogAnalyzer: analyzing {log_file_path} with deployment "
         f"{os.environ['AZURE_OPENAI_DEPLOYMENT_NAME']}"
@@ -55,6 +73,8 @@ def main():
         log(f"MicrobotsLogAnalyzer: max iterations is {max_iterations}")
     if args.output_file:
         log(f"MicrobotsLogAnalyzer: analysis output file is {args.output_file}")
+    if args.debug_log_file:
+        log(f"MicrobotsLogAnalyzer: debugging log file is {args.debug_log_file}")
     if args.user_prompt:
         log("MicrobotsLogAnalyzer: additional user context was provided")
 

--- a/azure-pipelines/MicrobotsLogAnalyzerTask/task.json
+++ b/azure-pipelines/MicrobotsLogAnalyzerTask/task.json
@@ -8,7 +8,7 @@
   "author": "Microbots contributors",
   "version": {
     "Major": 0,
-    "Minor": 4,
+    "Minor": 5,
     "Patch": 0
   },
   "instanceNameFormat": "Microbots Log Analyzer: $(logFilePath)",
@@ -64,6 +64,13 @@
       "label": "Analysis output file path",
       "required": false,
       "helpMarkDown": "Optional absolute path to a .txt, .md, or .log file where the LLM analysis result will be written. The file does not need to exist; the task creates missing directories and replaces any existing file contents."
+    },
+    {
+      "name": "debuggingLogFile",
+      "type": "string",
+      "label": "Debugging log file path",
+      "required": false,
+      "helpMarkDown": "Optional absolute path to a .txt, .md, or .log file where the analyzer's runtime logs (the bot's step-by-step thoughts, tool calls, and command outputs) will be written. The file does not need to exist; the task creates missing directories and overwrites any existing file contents."
     },
     {
       "name": "additionalContext",

--- a/azure-pipelines/MicrobotsLogAnalyzerTask/test/index.test.js
+++ b/azure-pipelines/MicrobotsLogAnalyzerTask/test/index.test.js
@@ -153,6 +153,7 @@ def get_bearer_token_provider(credential, scope):
 `);
   writeFile(path.join(mockModules, "microbots.py"), `
 import json
+import logging
 import os
 from types import SimpleNamespace
 
@@ -168,6 +169,7 @@ class LogAnalysisBot:
         self.token_provider = token_provider
 
     def run(self, **kwargs):
+        logging.getLogger("microbots.MicroBot").info("MOCK_TRAJECTORY LLM tool call: ls -1 /var/log")
         record = {
             "model": self.model,
             "folder_to_mount": self.folder_to_mount,
@@ -317,6 +319,30 @@ test("Optional Output File Path Must Be Absolute Plain Text Path", () => {
   assert.equal(logInputs.outputFilePath, path.join(codebasePath, "out", "analysis.log"));
 });
 
+test("Optional Debugging Log File Must Be Absolute Allowed-Extension Path", () => {
+  const { task } = loadTask();
+  const codebasePath = makeProjectWithLog();
+  const validInputs = {
+    codebasePath,
+    logFilePath: "logs/build.log",
+    endpoint: "https://example.openai.azure.com/",
+    timeoutSeconds: "600",
+  };
+
+  assert.throws(
+    () => task.validateInputs({ ...validInputs, debuggingLogFile: "trajectory.log" }),
+    /debuggingLogFile must be an absolute path/
+  );
+  assert.throws(
+    () => task.validateInputs({ ...validInputs, debuggingLogFile: path.join(codebasePath, "trajectory.json") }),
+    /debuggingLogFile must end with .txt, .md, or .log/
+  );
+
+  const inputs = { ...validInputs, debuggingLogFile: path.join(codebasePath, "out", "trajectory.log") };
+  task.validateInputs(inputs);
+  assert.equal(inputs.debuggingLogFile, path.join(codebasePath, "out", "trajectory.log"));
+});
+
 test("Invalid Inputs Are Rejected: endpoint, timeout, and maxIterations", () => {
   const { task } = loadTask();
   const codebasePath = makeProjectWithLog();
@@ -425,6 +451,39 @@ test("Optional Additional Context Is Passed To LogAnalysisBot", async () => {
     max_iterations: 12,
     user_prompt: "Prefer dependency restore failures as the likely root cause.",
   });
+});
+
+test("Optional Debugging Log File Captures Runtime Trajectory", async () => {
+  const debugRoot = fs.mkdtempSync(path.join(os.tmpdir(), "microbots-debug-test-"));
+  const debuggingLogFile = path.join(debugRoot, "nested", "trajectory.log");
+
+  const { calls, runnerResult } = await runTaskWithMockServiceConnectionAndMockMicrobots({
+    inputs: { debuggingLogFile },
+  });
+
+  const runnerCall = calls.spawnSync.find((call) => (
+    call.args[0] === path.join(taskDir, "log_analyzer_runner.py")
+  ));
+  assert.ok(runnerCall);
+  const runnerArgs = Array.from(runnerCall.args);
+  assert.ok(runnerArgs.includes("--debug-log-file"));
+  assert.equal(runnerArgs[runnerArgs.indexOf("--debug-log-file") + 1], debuggingLogFile);
+
+  assert.equal(runnerResult.status, 0, runnerResult.stderr);
+  assert.equal(fs.existsSync(debuggingLogFile), true);
+  const trajectory = fs.readFileSync(debuggingLogFile, "utf8");
+  assert.match(trajectory, /MOCK_TRAJECTORY LLM tool call: ls -1 \/var\/log/);
+  assert.match(trajectory, /microbots\.MicroBot INFO/);
+});
+
+test("Debugging Log File Is Skipped When Not Provided", async () => {
+  const { calls } = await runTaskWithMockServiceConnectionAndMockMicrobots();
+
+  const runnerCall = calls.spawnSync.find((call) => (
+    call.args[0] === path.join(taskDir, "log_analyzer_runner.py")
+  ));
+  assert.ok(runnerCall);
+  assert.ok(!Array.from(runnerCall.args).includes("--debug-log-file"));
 });
 
 test("Existing Python Environment Is Reused Only After A Completed Setup", () => {

--- a/azure-pipelines/vss-extension.json
+++ b/azure-pipelines/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "microbots-log-analyzer",
   "name": "Microbots Log Analyzer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "Microbots-log-analyzer",
   "targets": [
     {

--- a/docs/advanced/azure-pipelines-log-analyzer.md
+++ b/docs/advanced/azure-pipelines-log-analyzer.md
@@ -44,6 +44,7 @@ See the complete sample pipeline at [microbots-log-analyzer.yml](https://github.
     codebasePath: $(Build.SourcesDirectory)
     logFilePath: logs/build.log
     outputFilePath: $(Build.ArtifactStagingDirectory)/microbots-log-analysis.md
+    debuggingLogFile: $(Build.ArtifactStagingDirectory)/microbots-log-analysis-trajectory.log
     additionalContext: |
       This build usually fails when package version conflicts occur.
       Please consider it while analyzing the log.
@@ -54,6 +55,8 @@ See the complete sample pipeline at [microbots-log-analyzer.yml](https://github.
 The log file must exist before `MicrobotsLogAnalyzer@0` runs. Relative `logFilePath` values are resolved from `codebasePath`; absolute paths are also supported.
 
 `outputFilePath` is optional. When it is provided, it must be an absolute path ending in `.txt`, `.md`, or `.log`. The file does not need to exist; the task creates missing directories and replaces any existing file content with the latest LLM analysis result.
+
+`debuggingLogFile` is optional. When it is provided, it must be an absolute path ending in `.txt`, `.md`, or `.log`. The task writes the bot's runtime trajectory to it — the step-by-step LLM thoughts, tool calls, and command outputs that show how the analysis was reached. The file does not need to exist; the task creates missing directories and overwrites any existing file content. When it is omitted, no trajectory file is written and behavior is unchanged.
 
 `additionalContext` is optional. When provided, it is appended as extra user context for the log analysis and does not replace or override the Microbots system prompt. Maximum length: 1024 characters.
 
@@ -74,6 +77,7 @@ The log file must exist before `MicrobotsLogAnalyzer@0` runs. Relative `logFileP
 | `codebasePath` | Yes | - | Repository or source folder Microbots can inspect while analyzing the log. |
 | `logFilePath` | Yes | - | Log file path. Use an absolute path, or a relative path resolved from `codebasePath`. |
 | `outputFilePath` | No | - | Absolute `.txt`, `.md`, or `.log` path where the LLM analysis result is written. Missing directories are created, and existing file contents are replaced. |
+| `debuggingLogFile` | No | - | Absolute `.txt`, `.md`, or `.log` path where the bot's runtime trajectory (step-by-step LLM thoughts, tool calls, and command outputs) is written. Missing directories are created, and existing file contents are replaced. Omit to skip. |
 | `additionalContext` | No | - | Additional user context appended to the log analysis prompt. Maximum length: 1024 characters. |
 | `timeoutSeconds` | No | `600` | Maximum time for `LogAnalysisBot.run()`. |
 | `maxIterations` | No | `20` | Maximum number of Microbots iterations. Leave unset to use the default from `LogAnalysisBot.run()`. |
@@ -88,6 +92,7 @@ The log file must exist before `MicrobotsLogAnalyzer@0` runs. Relative `logFileP
 4. The task installs `microbots[azure_ad]` into that virtual environment.
 5. A short Python runner creates `LogAnalysisBot` with `AzureCliCredential`, mounts `codebasePath` as context, passes `logFilePath`, optional `additionalContext`, optional `maxIterations`, and `timeoutSeconds` to `LogAnalysisBot.run()`, and prints the analysis result.
 6. If `outputFilePath` is provided, the task writes the LLM analysis result to that file, replacing any existing contents.
+7. If `debuggingLogFile` is provided, the task captures the bot's runtime logs (LLM thoughts, tool calls, and command outputs) to that file, replacing any existing contents.
 
 The task clears the Azure CLI account at the end of the run. Its task manifest also uses Azure Pipelines command restrictions so analyzed log content cannot run arbitrary logging commands or set pipeline variables.
 

--- a/docs/examples/azure-pipelines/microbots-log-analyzer.yml
+++ b/docs/examples/azure-pipelines/microbots-log-analyzer.yml
@@ -26,6 +26,7 @@ jobs:
       codebasePath: $(Build.SourcesDirectory)
       logFilePath: logs/build.log
       outputFilePath: $(Build.ArtifactStagingDirectory)/microbots-log-analysis.md
+      debuggingLogFile: $(Build.ArtifactStagingDirectory)/microbots-log-analysis-trajectory.log
       additionalContext: |
         This build usually fails when package version conflicts occur.
         Please consider it while analyzing the log.


### PR DESCRIPTION
Publish the INFO level logs (LLM thought process, tool calls, etc) into an optional Debugging Log File provided in the ADO task.